### PR TITLE
Rename project from arizona_web to arizona_website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# arizona_web
+# arizona_website
 
-An Arizona application.
+Arizona Framework official website.
 
 ## Build
 

--- a/rebar.config
+++ b/rebar.config
@@ -10,4 +10,4 @@
     {rebar3_arizona, {git, "https://github.com/arizona-framework/rebar3_arizona.git", {branch, "main"}}}
 ]}.
 
-{shell, [{apps, [arizona_web]}]}.
+{shell, [{apps, [arizona_website]}]}.

--- a/site/index.html
+++ b/site/index.html
@@ -14,14 +14,14 @@
     <meta property="og:url" content="https://arizona-framework.github.io/">
     <meta property="og:title" content="Arizona Framework - Real-time Web Applications">
     <meta property="og:description" content="Build real-time web applications with Erlang/OTP. Modern, fault-tolerant web framework with real-time interactivity and BEAM performance.">
-    <meta property="og:image" content="https://github.com/arizona-framework/arizona_web/raw/main/priv/static/images/arizona_512x512.jpeg">
+    <meta property="og:image" content="https://github.com/arizona-framework/arizona_website/raw/main/priv/static/images/arizona_512x512.jpeg">
 
     
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://arizona-framework.github.io/">
     <meta property="twitter:title" content="Arizona Framework - Real-time Web Applications">
     <meta property="twitter:description" content="Build real-time web applications with Erlang/OTP. Modern, fault-tolerant web framework with real-time interactivity and BEAM performance.">
-    <meta property="twitter:image" content="https://github.com/arizona-framework/arizona_web/raw/main/priv/static/images/arizona_512x512.jpeg">
+    <meta property="twitter:image" content="https://github.com/arizona-framework/arizona_website/raw/main/priv/static/images/arizona_512x512.jpeg">
 
     <link rel="stylesheet" href="assets/app.css">
     <script src="assets/main.js"></script>

--- a/src/arizona_website.app.src
+++ b/src/arizona_website.app.src
@@ -1,7 +1,7 @@
-{application, arizona_web, [
-    {description, "An Arizona application"},
+{application, arizona_website, [
+    {description, "Arizona Framework official website"},
     {vsn, "0.1.0"},
-    {mod, {arizona_web_app, []}},
+    {mod, {arizona_website_app, []}},
     {applications, [
         kernel,
         stdlib,

--- a/src/arizona_website_app.erl
+++ b/src/arizona_website_app.erl
@@ -1,4 +1,4 @@
--module(arizona_web_app).
+-module(arizona_website_app).
 -behaviour(application).
 
 -export([start/2]).
@@ -10,8 +10,8 @@
     StartRet :: {ok, pid()} | {error, term()}.
 start(_StartType, _StartArgs) ->
     maybe
-        {ok, SupPid} ?= arizona_web_sup:start_link(),
-        ok ?= arizona:start(arizona_web_conf:arizona()),
+        {ok, SupPid} ?= arizona_website_sup:start_link(),
+        ok ?= arizona:start(arizona_website_conf:arizona()),
         ok = io:format("Arizona app started at http://localhost:1912~n"),
         {ok, SupPid}
     else

--- a/src/arizona_website_components.erl
+++ b/src/arizona_website_components.erl
@@ -1,4 +1,4 @@
--module(arizona_web_components).
+-module(arizona_website_components).
 -compile({parse_transform, arizona_parse_transform}).
 -export([
     feature_card/1,

--- a/src/arizona_website_conf.erl
+++ b/src/arizona_website_conf.erl
@@ -1,4 +1,4 @@
--module(arizona_web_conf).
+-module(arizona_website_conf).
 
 -export([arizona/0]).
 
@@ -28,18 +28,18 @@ arizona() ->
 
 routes() ->
     [
-        {asset, ~"/favicon.ico", {priv_file, arizona_web, ~"static/favicon.ico"}},
-        {asset, ~"/robots.txt", {priv_file, arizona_web, ~"static/robots.txt"}},
-        {asset, ~"/assets/main.js", {priv_file, arizona_web, ~"static/assets/main.js"}},
-        {asset, ~"/assets/prism.js", {priv_file, arizona_web, ~"static/assets/prism.js"}},
-        {asset, ~"/assets/dev.js", {priv_file, arizona_web, ~"static/assets/dev.js"}},
-        {asset, ~"/assets/app.css", {priv_file, arizona_web, ~"static/assets/app.css"}},
+        {asset, ~"/favicon.ico", {priv_file, arizona_website, ~"static/favicon.ico"}},
+        {asset, ~"/robots.txt", {priv_file, arizona_website, ~"static/robots.txt"}},
+        {asset, ~"/assets/main.js", {priv_file, arizona_website, ~"static/assets/main.js"}},
+        {asset, ~"/assets/prism.js", {priv_file, arizona_website, ~"static/assets/prism.js"}},
+        {asset, ~"/assets/dev.js", {priv_file, arizona_website, ~"static/assets/dev.js"}},
+        {asset, ~"/assets/app.css", {priv_file, arizona_website, ~"static/assets/app.css"}},
         {asset, ~"/assets", {priv_dir, arizona, ~"static/assets"}},
-        {asset, ~"/images/arizona_256x256.jpeg", {priv_file, arizona_web, ~"static/images/arizona_256x256.jpeg"}},
-        {asset, ~"/images/arizona_512x512.jpeg", {priv_file, arizona_web, ~"static/images/arizona_512x512.jpeg"}},
-        {asset, ~"/images", {priv_dir, arizona_web, ~"static/images"}},
+        {asset, ~"/images/arizona_256x256.jpeg", {priv_file, arizona_website, ~"static/images/arizona_256x256.jpeg"}},
+        {asset, ~"/images/arizona_512x512.jpeg", {priv_file, arizona_website, ~"static/images/arizona_512x512.jpeg"}},
+        {asset, ~"/images", {priv_dir, arizona_website, ~"static/images"}},
         {websocket, ~"/live"},
-        {view, ~"/", arizona_web_view, {arizona_web_home_page, #{}}}
+        {view, ~"/", arizona_website_view, {arizona_website_home_page, #{}}}
     ].
 
 compile_erl(Files) ->

--- a/src/arizona_website_home_page.erl
+++ b/src/arizona_website_home_page.erl
@@ -1,4 +1,4 @@
--module(arizona_web_home_page).
+-module(arizona_website_home_page).
 -behaviour(arizona_stateful).
 -compile({parse_transform, arizona_parse_transform}).
 -export([mount/1]).
@@ -31,7 +31,7 @@ header() ->
         <nav class="container mx-auto px-6 py-4">
             <div class="flex items-center justify-between">
                 <a href="/" class="flex items-center space-x-3 hover:opacity-80 transition-opacity duration-300">
-                    {arizona_template:render_stateless(arizona_web_components, arizona_image, #{
+                    {arizona_template:render_stateless(arizona_website_components, arizona_image, #{
                         type => logo,
                         size => medium,
                         alt => ~"Arizona Framework",
@@ -45,7 +45,7 @@ header() ->
                 <div class="hidden md:flex items-center space-x-8">
                     {arizona_template:render_list(fun(Link) ->
                         arizona_template:from_string(~"""
-                        {arizona_template:render_stateless(arizona_web_components, nav_link, Link)}
+                        {arizona_template:render_stateless(arizona_website_components, nav_link, Link)}
                         """)
                     end, header_links())}
                 </div>
@@ -79,7 +79,7 @@ hero() ->
             <!-- Large Arizona Logo -->
             <div class="flex justify-center mb-8">
                 <div class="relative">
-                    {arizona_template:render_stateless(arizona_web_components, arizona_image, #{
+                    {arizona_template:render_stateless(arizona_website_components, arizona_image, #{
                         type => logo,
                         size => large,
                         alt => ~"Arizona Framework Logo",
@@ -136,7 +136,7 @@ hero() ->
             <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
                 {arizona_template:render_list(fun(Button) ->
                     arizona_template:from_string(~"""
-                    {arizona_template:render_stateless(arizona_web_components, cta_button, Button)}
+                    {arizona_template:render_stateless(arizona_website_components, cta_button, Button)}
                     """)
                 end, cta_buttons())}
             </div>
@@ -170,7 +170,7 @@ features() ->
             <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
                 {arizona_template:render_list(fun(Feature) ->
                     arizona_template:from_string(~"""
-                    {arizona_template:render_stateless(arizona_web_components, feature_card, Feature)}
+                    {arizona_template:render_stateless(arizona_website_components, feature_card, Feature)}
                     """)
                 end, feature_list())}
             </div>
@@ -181,7 +181,7 @@ features() ->
 feature_list() ->
     [
         #{
-            icon => arizona_template:render_stateless(arizona_web_components, svg_icon, #{type => lightning}),
+            icon => arizona_template:render_stateless(arizona_website_components, svg_icon, #{type => lightning}),
             title => ~"Real-time Updates",
             description => [
                 ~"Built-in PubSub system enables real-time updates across connected ",
@@ -189,7 +189,7 @@ feature_list() ->
             ]
         },
         #{
-            icon => arizona_template:render_stateless(arizona_web_components, svg_icon, #{type => chart}),
+            icon => arizona_template:render_stateless(arizona_website_components, svg_icon, #{type => chart}),
             title => ~"BEAM Performance",
             description => [
                 ~"Built on Erlang/OTP, Arizona inherits the legendary fault-tolerance, ",
@@ -197,7 +197,7 @@ feature_list() ->
             ]
         },
         #{
-            icon => arizona_template:render_stateless(arizona_web_components, svg_icon, #{type => code}),
+            icon => arizona_template:render_stateless(arizona_website_components, svg_icon, #{type => code}),
             title => ~"Developer Experience",
             description => [
                 ~"Clean template syntax, hot code reloading, and comprehensive development ",
@@ -317,7 +317,7 @@ performance_stats() ->
             <div class="grid md:grid-cols-3 gap-8">
                 {arizona_template:render_list(fun(Stat) ->
                     arizona_template:from_string(~"""
-                    {arizona_template:render_stateless(arizona_web_components, stat_card, Stat)}
+                    {arizona_template:render_stateless(arizona_website_components, stat_card, Stat)}
                     """)
                 end, performance_stats_list())}
             </div>
@@ -350,7 +350,7 @@ footer() ->
     <footer class="py-12 px-6 border-t border-slate bg-obsidian bg-opacity-50">
         <div class="container mx-auto text-center">
             <div class="flex items-center justify-center space-x-3 mb-6">
-                {arizona_template:render_stateless(arizona_web_components, arizona_image, #{
+                {arizona_template:render_stateless(arizona_website_components, arizona_image, #{
                     type => logo,
                     size => small,
                     alt => ~"Arizona Framework",
@@ -366,7 +366,7 @@ footer() ->
             <div class="flex flex-col sm:flex-row justify-center items-center gap-4 sm:gap-6">
                 {arizona_template:render_list(fun(Link) ->
                     arizona_template:from_string(~"""
-                    {arizona_template:render_stateless(arizona_web_components, nav_link, Link)}
+                    {arizona_template:render_stateless(arizona_website_components, nav_link, Link)}
                     """)
                 end, footer_links())}
             </div>

--- a/src/arizona_website_layout.erl
+++ b/src/arizona_website_layout.erl
@@ -1,4 +1,4 @@
--module(arizona_web_layout).
+-module(arizona_website_layout).
 -compile({parse_transform, arizona_parse_transform}).
 -export([render/1]).
 
@@ -30,7 +30,7 @@ render(Bindings) ->
             ~"web framework with real-time interactivity and BEAM performance."
         ]}">
         <meta property="og:image" content="{[
-            ~"https://github.com/arizona-framework/arizona_web/raw/main",
+            ~"https://github.com/arizona-framework/arizona_website/raw/main",
             ~"/priv/static/images/arizona_512x512.jpeg"
         ]}">
 
@@ -43,7 +43,7 @@ render(Bindings) ->
             ~"web framework with real-time interactivity and BEAM performance."
         ]}">
         <meta property="twitter:image" content="{[
-            ~"https://github.com/arizona-framework/arizona_web/raw/main",
+            ~"https://github.com/arizona-framework/arizona_website/raw/main",
             ~"/priv/static/images/arizona_512x512.jpeg"
         ]}">
 

--- a/src/arizona_website_static.erl
+++ b/src/arizona_website_static.erl
@@ -1,8 +1,8 @@
--module(arizona_web_static).
+-module(arizona_website_static).
 -export([generate/0]).
 
 generate() ->
-    ok = application:set_env(arizona_web, env, prod),
+    ok = application:set_env(arizona_website, env, prod),
     {ok, Cwd} = file:get_cwd(),
     OutputDir = filename:join([Cwd, "site"]),
     ok =
@@ -34,5 +34,5 @@ generate() ->
                 io:format("Failed to generate static site: ~p~n", [Reason]),
                 {error, Reason}
         end,
-    ok = application:set_env(arizona_web, env, dev),
+    ok = application:set_env(arizona_website, env, dev),
     Result.

--- a/src/arizona_website_sup.erl
+++ b/src/arizona_website_sup.erl
@@ -1,4 +1,4 @@
--module(arizona_web_sup).
+-module(arizona_website_sup).
 -behaviour(supervisor).
 
 -export([start_link/0]).

--- a/src/arizona_website_view.erl
+++ b/src/arizona_website_view.erl
@@ -1,4 +1,4 @@
--module(arizona_web_view).
+-module(arizona_website_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
 -export([mount/2]).
@@ -13,8 +13,8 @@ mount({Page, PageBindings}, _Req) ->
         page_bindings => PageBindings#{id => ~"page"}
     },
     Layout =
-        {arizona_web_layout, render, main_content, #{
-            env => application:get_env(arizona_web, env, dev),
+        {arizona_website_layout, render, main_content, #{
+            env => application:get_env(arizona_website, env, dev),
             title => ~"Arizona Framework"
         }},
     arizona_view:new(?MODULE, Bindings, Layout).


### PR DESCRIPTION
- Rename all Erlang modules from arizona_web_* to arizona_website_*
- Update application configuration and references
- Update README.md with new project name and description
- Fix GitHub image URLs in layout template and static site
- Update rebar.config shell application reference
- Project now clearly identifies as the official Arizona Framework website