### PR TITLE
Add Netlify deployment status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Arizona Website
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/f52c6501-93d0-4298-91b9-4d8297b48823/deploy-status)](https://app.netlify.com/projects/arizonaframework/deploys)
+
 The official website for the Arizona Framework - a modern Erlang web framework
 for building real-time web applications.
 


### PR DESCRIPTION
- Display current deployment status in README header
- Link badge to Netlify deployment dashboard for easy access
- Provide visual confirmation of successful deployments
- Follow conventional badge placement for project status