### PR TITLE
Fix social media previews and crawler access

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -11,14 +11,14 @@
 
     
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://arizona-framework.github.io/">
+    <meta property="og:url" content="https://arizonaframework.org/">
     <meta property="og:title" content="Arizona Framework - Real-time Web Applications">
     <meta property="og:description" content="Build real-time web applications with Erlang/OTP. Modern, fault-tolerant web framework with real-time interactivity and BEAM performance.">
     <meta property="og:image" content="https://github.com/arizona-framework/arizona_website/raw/main/priv/static/images/arizona_512x512.jpeg">
 
     
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://arizona-framework.github.io/">
+    <meta property="twitter:url" content="https://arizonaframework.org/">
     <meta property="twitter:title" content="Arizona Framework - Real-time Web Applications">
     <meta property="twitter:description" content="Build real-time web applications with Erlang/OTP. Modern, fault-tolerant web framework with real-time interactivity and BEAM performance.">
     <meta property="twitter:image" content="https://github.com/arizona-framework/arizona_website/raw/main/priv/static/images/arizona_512x512.jpeg">

--- a/dist/robots.txt
+++ b/dist/robots.txt
@@ -1,5 +1,6 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
+
 User-agent: *
-Disallow: /
+Allow: /
+
+Sitemap: https://arizonaframework.org/sitemap.xml

--- a/dist/sitemap.xml
+++ b/dist/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://example.com/</loc>
+    <loc>https://arizonaframework.org/</loc>
     <changefreq>weekly</changefreq>
   </url>
 </urlset>

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,5 +1,6 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
+
 User-agent: *
-Disallow: /
+Allow: /
+
+Sitemap: https://arizonaframework.org/sitemap.xml

--- a/src/arizona_website_layout.erl
+++ b/src/arizona_website_layout.erl
@@ -23,7 +23,7 @@ render(Bindings) ->
 
         {% Open Graph / Facebook }
         <meta property="og:type" content="website">
-        <meta property="og:url" content="https://arizona-framework.github.io/">
+        <meta property="og:url" content="https://arizonaframework.org/">
         <meta property="og:title" content="Arizona Framework - Real-time Web Applications">
         <meta property="og:description" content="{[
             ~"Build real-time web applications with Erlang/OTP. Modern, fault-tolerant ",
@@ -36,7 +36,7 @@ render(Bindings) ->
 
         {% Twitter }
         <meta property="twitter:card" content="summary_large_image">
-        <meta property="twitter:url" content="https://arizona-framework.github.io/">
+        <meta property="twitter:url" content="https://arizonaframework.org/">
         <meta property="twitter:title" content="Arizona Framework - Real-time Web Applications">
         <meta property="twitter:description" content="{[
             ~"Build real-time web applications with Erlang/OTP. Modern, fault-tolerant ",

--- a/src/arizona_website_static.erl
+++ b/src/arizona_website_static.erl
@@ -13,6 +13,7 @@ generate() ->
 
     % Configuration for static site generation
     Config = #{
+        base_url => ~"https://arizonaframework.org",
         route_paths => #{
             ~"/" => #{parallel => true},
             ~"/favicon.ico" => #{parallel => true},


### PR DESCRIPTION
- Update Open Graph URLs from GitHub Pages to arizonaframework.org domain
- Fix robots.txt to allow crawlers instead of blocking them
- Add sitemap reference to robots.txt for better SEO
- Regenerate static site with corrected metadata
- Enable LinkedIn and other social platforms to properly preview the site