### PR TITLE
Fix README to accurately describe static website

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ for building real-time web applications.
 
 ## Overview
 
-This project showcases the Arizona Framework's capabilities through an
-interactive website featuring:
+This project showcases the Arizona Framework's capabilities through a
+static website featuring:
 
-- **Real-time interactivity** with WebSocket-based updates
 - **Component-based architecture** with reusable UI components
 - **Static site generation** for deployment
 - **Responsive design** with Tailwind CSS


### PR DESCRIPTION
- Remove misleading "interactive website" and "real-time interactivity" claims
- Correctly describe as "static website" showcasing Arizona's capabilities
- Remove WebSocket reference as this site doesn't use real-time features
- Maintain focus on actual features: components, static generation, responsive design