### PR TITLE
Adapt to new Arizona Framework action list reply format

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -264,7 +264,7 @@ render(Bindings) -&gt;
 handle_event(~&quot;increment&quot;, _Params, State) -&gt;
     Count = arizona_stateful:get_binding(count, State),
     UpdatedState = arizona_stateful:put_binding(count, Count + 1, State),
-    {noreply, UpdatedState}.
+    {[], UpdatedState}.
                         </code>
                     </pre>
                 </div>

--- a/src/arizona_website_home_page.erl
+++ b/src/arizona_website_home_page.erl
@@ -302,7 +302,7 @@ example() ->
     handle_event(~"increment", _Params, State) ->
         Count = arizona_stateful:get_binding(count, State),
         UpdatedState = arizona_stateful:put_binding(count, Count + 1, State),
-        {noreply, UpdatedState}.
+        {[], UpdatedState}.
     """".
 
 %% Performance stats component

--- a/src/arizona_website_view.erl
+++ b/src/arizona_website_view.erl
@@ -30,7 +30,7 @@ render(Bindings) ->
     """).
 
 handle_event(~"reload", FileType, View) ->
-    {reply, #{~"reload" => FileType}, View}.
+    {[{reply, #{~"reload" => FileType}}], View}.
 
 initialize_connected_session() ->
     arizona_pubsub:join(~"reload", self()).


### PR DESCRIPTION
- Update handle_event return format to use action lists
- Change {reply, Action, State} to {[{reply, Action}], State}
- Change {noreply, State} to {[], State}
- Maintain compatibility with latest Arizona Framework API
- Update static site with regenerated content